### PR TITLE
feat: Add edit functionality to context menu

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -266,6 +266,7 @@
 
   <div id="contextMenu" class="context-menu">
     <button id="menuGoToButton"><span>Go to Video</span></button>
+    <button id="menuEditButton"><span>Edit</span></button>
     <button id="menuCopyButton"><span>Copy</span></button>
     <button id="menuDeleteButton"><span>Delete</span></button>
     <button id="menuMoveUpButton"><span>Move Up</span><span class="arrow">🡩</span></button>

--- a/popup.js
+++ b/popup.js
@@ -211,6 +211,7 @@ document.addEventListener('DOMContentLoaded', () => {
     // --- Context Menu Logic ---
     const contextMenu = document.getElementById('contextMenu');
     const menuGoToButton = document.getElementById('menuGoToButton');
+    const menuEditButton = document.getElementById('menuEditButton');
     const menuCopyButton = document.getElementById('menuCopyButton');
     const menuMoveUpButton = document.getElementById('menuMoveUpButton');
     const menuMoveDownButton = document.getElementById('menuMoveDownButton');
@@ -261,6 +262,34 @@ document.addEventListener('DOMContentLoaded', () => {
             const video = state.lists[state.activeList][selectedRecordIndex];
             if (video && video.url) {
                 chrome.tabs.create({ url: video.url });
+            }
+        }
+        contextMenu.style.display = 'none';
+    });
+
+    // Action: Edit record
+    menuEditButton.addEventListener('click', () => {
+        if (selectedRecordIndex !== -1) {
+            const list = state.lists[state.activeList];
+            const video = list[selectedRecordIndex];
+
+            const newTitle = prompt("Enter the new title:", video.title);
+
+            if (newTitle !== null && newTitle.trim() !== '') {
+                // Create a new video object to avoid direct state mutation
+                const updatedVideo = { ...video, title: newTitle.trim() };
+
+                // Create a new list array with the updated video
+                const updatedList = [
+                    ...list.slice(0, selectedRecordIndex),
+                    updatedVideo,
+                    ...list.slice(selectedRecordIndex + 1)
+                ];
+
+                // Update state and save
+                state.lists[state.activeList] = updatedList; // Update state directly
+                chrome.storage.local.set({ lists: state.lists });
+                render(); // Re-render the UI
             }
         }
         contextMenu.style.display = 'none';


### PR DESCRIPTION
Adds an "Edit" option to the context menu that appears when clicking on a video in the list.

When the "Edit" button is clicked, a prompt appears allowing the user to enter a new title for the selected video. The list is then updated to reflect the change.